### PR TITLE
Fix/side improvements

### DIFF
--- a/include/jsxer.h
+++ b/include/jsxer.h
@@ -18,7 +18,7 @@ enum class JsxbinVersion : uint16_t {
 };
 
 namespace jsxer {
-    int decompile(const string& input, string& output, bool unblind = false);
+    int decompile(const string& input, string& output, bool unblind = false, bool includeJson2 = false);
 
-    int decompile_test(const string& input, string& output, bool unblind = false);
+    int decompile_test(const string& input, string& output, bool unblind = false, bool includeJson2 = false);
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -21,6 +21,7 @@ int main(int argc, char* argv[]) {
 
     // cli flag variables
     bool unblind = false;
+    bool includeJson2 = false;
 //    bool verbose = false;
     std::string input;
     std::string output;
@@ -35,6 +36,7 @@ int main(int argc, char* argv[]) {
 //    cli.add_flag("-v,--verbose",
 //                   verbose,
 //                   "Display verbose log");
+    cli.add_option("-j,--json2", includeJson2, "Include Json2");
 
     cli.add_option("input",
                    input,
@@ -66,7 +68,7 @@ int main(int argc, char* argv[]) {
     // begin de-compilation...
     std::string decompiled;
     std::cout << "[i] Decompiling..." << std::endl;
-    jsxer::decompile(contents_str, decompiled, unblind);
+    jsxer::decompile(contents_str, decompiled, unblind, includeJson2);
     std::cout << "[i] Finished." << std::endl;
 
     utils::WriteFileContents(output_path, decompiled);

--- a/src/jsxer/decoders.cpp
+++ b/src/jsxer/decoders.cpp
@@ -269,12 +269,15 @@ bool valid_id_x(uint32_t value) {
     return valid_id_0(value) || is_numerical_digit(value);
 }
 
+inline
+bool not_keyword(const string& value) {
+    return value != "static" && value != "default";
+}
+
 // decoding utilities...
 bool jsxer::decoders::valid_id(const string& value) {
     // ^[a-zA-Z_$][0-9a-zA-Z_$]*$
-    size_t len = value.length();
-
-    if (len > 0) {
+    if (size_t len = value.length(); len > 0) {
         if (valid_id_0(value[0])) {
             for (int i = 1; i < len; ++i) {
                 if (!valid_id_x(value[i])) {
@@ -288,14 +291,18 @@ bool jsxer::decoders::valid_id(const string& value) {
         return false;
     }
 
-    return true;
+    return not_keyword(value);
+}
+
+inline
+bool not_keyword(const ByteString& value) {
+    // TODO: lame
+    return value != ByteString{'s', 't', 'a', 't', 'i', 'c'} && value != ByteString{'d', 'e', 'f', 'a', 'u', 'l', 't'};
 }
 
 bool jsxer::decoders::valid_id(const ByteString& value) {
     // ^[a-zA-Z_$][0-9a-zA-Z_$]*$
-    size_t len = value.size();
-
-    if (len > 0) {
+    if (size_t len = value.size(); len > 0) {
         if (valid_id_0(value[0])) {
             for (int i = 1; i < len; ++i) {
                 if (!valid_id_x(value[i])) {
@@ -309,7 +316,7 @@ bool jsxer::decoders::valid_id(const ByteString& value) {
         return false;
     }
 
-    return true;
+    return not_keyword(value);
 }
 
 bool jsxer::decoders::valid_xml_attribute(const ByteString& value) {

--- a/src/jsxer/jsxer.cpp
+++ b/src/jsxer/jsxer.cpp
@@ -36,8 +36,8 @@ void prepend_header(string& code, JsxbinVersion jsxbin_version, bool unblind) {
     code = header + code;
 }
 
-int jsxer::decompile(const string& input, string& output, bool unblind) {
-    auto reader = std::make_unique<Reader>(input, unblind);
+int jsxer::decompile(const string& input, string& output, bool unblind, bool includeJson2) {
+    auto reader = std::make_unique<Reader>(input, unblind, includeJson2);
 
     if (!reader->verifySignature()) {
         // TODO: Handle this properly
@@ -59,8 +59,8 @@ int jsxer::decompile(const string& input, string& output, bool unblind) {
 }
 
 // for testing
-int jsxer::decompile_test(const string& input, string& output, bool unblind) {
-    auto reader = std::make_unique<Reader>(input, unblind);
+int jsxer::decompile_test(const string& input, string& output, bool unblind, bool includeJson2) {
+    auto reader = std::make_unique<Reader>(input, unblind, includeJson2);
 
     if (!reader->verifySignature()) {
         // TODO: Handle this properly

--- a/src/jsxer/nodes/Program.cpp
+++ b/src/jsxer/nodes/Program.cpp
@@ -1,11 +1,24 @@
 #include "Program.h"
 
+namespace {
+    const char *Json2 = R"json2(/* https://cdnjs.cloudflare.com/ajax/libs/json2/20160511/json2.min.js */
+"object"!=typeof JSON&&(JSON={}),function(){"use strict";function f(t){return t<10?"0"+t:t}function this_value(){return this.valueOf()}function quote(t){return rx_escapable.lastIndex=0,rx_escapable.test(t)?'"'+t.replace(rx_escapable,function(t){var e=meta[t];return"string"==typeof e?e:"\\u"+("0000"+t.charCodeAt(0).toString(16)).slice(-4)})+'"':'"'+t+'"'}function str(t,e){var r,n,o,u,f,a=gap,i=e[t];switch(i&&"object"==typeof i&&"function"==typeof i.toJSON&&(i=i.toJSON(t)),"function"==typeof rep&&(i=rep.call(e,t,i)),typeof i){case"string":return quote(i);case"number":return isFinite(i)?String(i):"null";case"boolean":case"null":return String(i);case"object":if(!i)return"null";if(gap+=indent,f=[],"[object Array]"===Object.prototype.toString.apply(i)){for(u=i.length,r=0;r<u;r+=1)f[r]=str(r,i)||"null";return o=0===f.length?"[]":gap?"[\n"+gap+f.join(",\n"+gap)+"\n"+a+"]":"["+f.join(",")+"]",gap=a,o}if(rep&&"object"==typeof rep)for(u=rep.length,r=0;r<u;r+=1)"string"==typeof rep[r]&&(n=rep[r],o=str(n,i),o&&f.push(quote(n)+(gap?": ":":")+o));else for(n in i)Object.prototype.hasOwnProperty.call(i,n)&&(o=str(n,i),o&&f.push(quote(n)+(gap?": ":":")+o));return o=0===f.length?"{}":gap?"{\n"+gap+f.join(",\n"+gap)+"\n"+a+"}":"{"+f.join(",")+"}",gap=a,o}}var rx_one=/^[\],:{}\s]*$/,rx_two=/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,rx_three=/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,rx_four=/(?:^|:|,)(?:\s*\[)+/g,rx_escapable=/[\\\"\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,rx_dangerous=/[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;"function"!=typeof Date.prototype.toJSON&&(Date.prototype.toJSON=function(){return isFinite(this.valueOf())?this.getUTCFullYear()+"-"+f(this.getUTCMonth()+1)+"-"+f(this.getUTCDate())+"T"+f(this.getUTCHours())+":"+f(this.getUTCMinutes())+":"+f(this.getUTCSeconds())+"Z":null},Boolean.prototype.toJSON=this_value,Number.prototype.toJSON=this_value,String.prototype.toJSON=this_value);var gap,indent,meta,rep;"function"!=typeof JSON.stringify&&(meta={"\b":"\\b","\t":"\\t","\n":"\\n","\f":"\\f","\r":"\\r",'"':'\\"',"\\":"\\\\"},JSON.stringify=function(t,e,r){var n;if(gap="",indent="","number"==typeof r)for(n=0;n<r;n+=1)indent+=" ";else"string"==typeof r&&(indent=r);if(rep=e,e&&"function"!=typeof e&&("object"!=typeof e||"number"!=typeof e.length))throw new Error("JSON.stringify");return str("",{"":t})}),"function"!=typeof JSON.parse&&(JSON.parse=function(text,reviver){function walk(t,e){var r,n,o=t[e];if(o&&"object"==typeof o)for(r in o)Object.prototype.hasOwnProperty.call(o,r)&&(n=walk(o,r),void 0!==n?o[r]=n:delete o[r]);return reviver.call(t,e,o)}var j;if(text=String(text),rx_dangerous.lastIndex=0,rx_dangerous.test(text)&&(text=text.replace(rx_dangerous,function(t){return"\\u"+("0000"+t.charCodeAt(0).toString(16)).slice(-4)})),rx_one.test(text.replace(rx_two,"@").replace(rx_three,"]").replace(rx_four,"")))return j=eval("("+text+")"),"function"==typeof reviver?walk({"":j},""):j;throw new SyntaxError("JSON.parse")})}();
+//# sourceMappingURL=json2.min.js.map
+)json2";
+}
+
 namespace jsxer::nodes {
     void Program::parse() {
         body = decoders::d_node(reader);
     }
 
     string Program::to_string() {
-        return body->to_string();
+        std::string includes;
+        if (reader.should_include_json2()) {
+            includes += Json2;
+            includes += "\n";
+        }
+
+        return includes + body->to_string();
     }
 }

--- a/src/jsxer/reader.cpp
+++ b/src/jsxer/reader.cpp
@@ -8,7 +8,7 @@
 using namespace jsxer;
 #define perror(msg) printf("[!] " msg ", POS: %lu\n", this->_cursor)
 
-Reader::Reader(const string& jsxbin, bool unblind) {
+Reader::Reader(const string& jsxbin, bool unblind, bool includeJson2) {
     string _input = jsxbin;
 
     utils::string_strip_char(_input, ' ');
@@ -29,6 +29,7 @@ Reader::Reader(const string& jsxbin, bool unblind) {
     _error = ParseError::None;
     _version = JsxbinVersion::Invalid;
     _unblind = unblind;
+    _includeJson2 = includeJson2;
 }
 
 JsxbinVersion Reader::version() const {
@@ -45,6 +46,10 @@ size_t Reader::depth() const {
 
 bool Reader::should_unblind() const {
     return _unblind;
+}
+
+bool Reader::should_include_json2() const {
+    return _includeJson2;
 }
 
 void Reader::step(int offset) {

--- a/src/jsxer/reader.h
+++ b/src/jsxer/reader.h
@@ -69,12 +69,13 @@ using OpVariant = std::shared_ptr<Variant>;
 
 class Reader {
 public:
-    explicit Reader(const string& jsxbin, bool unblind);
+    explicit Reader(const string& jsxbin, bool unblind, bool includeJson2 = false);
 
     [[nodiscard]] JsxbinVersion version() const;
     [[nodiscard]] ParseError error() const;
     [[nodiscard]] size_t depth() const;
     [[nodiscard]] bool should_unblind() const;
+    [[nodiscard]] bool should_include_json2() const;
     bool verifySignature();
 
     Token get();
@@ -108,6 +109,7 @@ private:
     JsxbinVersion _version;
 
     bool _unblind;
+    bool _includeJson2;
     deob::DeobfuscationContext deobfuscationContext;
 
     map<Number, ByteString> _symbols;


### PR DESCRIPTION
Resolved cases in which there were problems running generated .jsx
- `JSON` missing (added CLI option `-j,--json2` which includes Json2)
- Keywords `default` and `static` as members are possible but not properly handled